### PR TITLE
Don't cast data to string before escape_and_quote() in add_file

### DIFF
--- a/lib/atech/object_store/file.rb
+++ b/lib/atech/object_store/file.rb
@@ -58,7 +58,7 @@ module Atech
         
         ##Create an insert query
         columns = options.keys.join('`,`')
-        data    = options.values.map { |data| escape_and_quote(data.to_s) }.join(',')
+        data    = options.values.map { |data| escape_and_quote(data) }.join(',')
         ObjectStore.backend.query("INSERT INTO files (`#{columns}`) VALUES (#{data})")
 
         ## Return a new File object
@@ -164,7 +164,7 @@ module Atech
       
       def self.escape_and_quote(string)
         string = string.strftime('%Y-%m-%d %H:%M:%S') if string.is_a?(Time)
-        "'#{ObjectStore.backend.escape(string)}'"
+        "'#{ObjectStore.backend.escape(string.to_s)}'"
       end
       
       def self.time_now


### PR DESCRIPTION
Doing so causes the timestamps to be converted to a format such as '2013-05-13 10:27:01 UTC' which can make MySQL unhappy.

```
Mysql2::Error (Incorrect datetime value: '2013-05-13 10:27:01 UTC' for column 'created_at' at row 1):
```
